### PR TITLE
Fix container-volume dropdown visibility

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -111,6 +111,7 @@
 
       contSel.onchange = () => {
         volSel.disabled = !contSel.value;
+        volSel.style.display = contSel.value ? '' : 'none';
         volSel.innerHTML = '<option value="" selected disabled>Menge</option>';
         const vols = contSel.value === 'Flasche'
           ? ['0,5 l','0,75 l','1 l']


### PR DESCRIPTION
## Summary
- keep volume dropdown hidden until container selection
- show the dropdown when the container is chosen

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685842a68b18832e9b76f9253bd6eb7c