### PR TITLE
Update local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Scripting & AJAX: jQuery
 
 Erweiterte Dropdowns: Select2
 
-Build-Tools: npm, serve
+Build-Tools: npm
 
 Versionierung: Git
 
@@ -45,9 +45,11 @@ Abhängigkeiten installieren:
 
 npm install
 
-Lokalen Webserver starten (z. B. mit serve):
+Lokalen Webserver starten:
 
-npx serve
+npm start
+
+Der Express-Server läuft über `node index.js` und bedient das Verzeichnis `public`.
 
 Im Browser öffnen:
 

--- a/public/Readme.txt
+++ b/public/Readme.txt
@@ -34,9 +34,11 @@ cd bosse-quick-order
 
 npm install
 
-	3.	Starte einen lokalen Webserver, beispielsweise mit serve:
+	3.	Starte den lokalen Webserver:
 
-npx serve
+npm start
+
+       Der Express-Server läuft über `node index.js` und bedient das Verzeichnis `public`.
 
 	4.	Öffne die Webseite in deinem Browser unter:
 


### PR DESCRIPTION
## Summary
- update README to use `npm start` instead of `serve`
- update public Readme accordingly
- clarify Express server startup and `public` directory

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685850b641b0832ea4c959e6d9c6f73d