### PR TITLE
Update README instructions for local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,13 @@ Abhängigkeiten installieren:
 
 npm install
 
-Lokalen Webserver starten (z. B. mit serve):
+Server starten:
 
-npx serve
+npm start # führt node index.js aus
+
+Alternativ nur das public-Verzeichnis bereitstellen:
+
+npx serve public
 
 Im Browser öffnen:
 

--- a/public/Readme.txt
+++ b/public/Readme.txt
@@ -34,9 +34,13 @@ cd bosse-quick-order
 
 npm install
 
-	3.	Starte einen lokalen Webserver, beispielsweise mit serve:
+        3.      Starte den Server:
 
-npx serve
+npm start # führt node index.js aus
+        Oder nur das public-Verzeichnis bereitstellen:
+
+npx serve public
+
 
 	4.	Öffne die Webseite in deinem Browser unter:
 


### PR DESCRIPTION
## Summary
- clarify steps to start the local server in README files
- show `npm start` usage and mention `npx serve public` as an alternative

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68585653b7fc832e9c97a0b1b29c80ff