### PR TITLE
Fix responsive width for container dropdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 w-100">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>
@@ -69,7 +69,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 w-100">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>

--- a/public/main.js
+++ b/public/main.js
@@ -179,7 +179,7 @@
           <img class="thumb" src="" alt="" height="48">
         </td>
         <td>
-          <div class="d-flex gap-1">
+          <div class="d-flex gap-1 w-100">
             <select class="form-select form-select-sm container-type">
               <option value="" selected disabled>Behälter</option>
               <option value="Flasche">Flasche</option>

--- a/public/style.css
+++ b/public/style.css
@@ -88,14 +88,15 @@ img.thumb {
   display: flex;
   flex-wrap: nowrap;
   gap: 0.25rem;
+  width: 100%;
 }
 
 #productTable td:nth-child(4) .container-type {
-  flex: 0 1 auto;  /* shrink if necessary */
+  flex: 0 1 40%;
   min-width: 0;
 }
 #productTable td:nth-child(4) .volume-select {
-  flex: 1 1 0;
+  flex: 1 1 60%;
   min-width: 0;
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -90,7 +90,10 @@ img.thumb {
   gap: 0.25rem;
 }
 
-#productTable td:nth-child(4) .container-type,
+#productTable td:nth-child(4) .container-type {
+  flex: 0 1 auto;  /* shrink if necessary */
+  min-width: 0;
+}
 #productTable td:nth-child(4) .volume-select {
   flex: 1 1 0;
   min-width: 0;
@@ -302,9 +305,9 @@ select.form-select {
   display: none;
 }
 
-/* Container-Dropdown behält eigene Breite */
+/* Container-Dropdown kann bei Bedarf schrumpfen */
 .container-type {
-  flex: 0 0 auto;
+  flex: 0 1 auto; /* allow shrinking on narrow screens */
   width: auto;
 }
 /* --- Responsive: Bild-Spalte ausblenden bei kleinen Viewports --- */


### PR DESCRIPTION
## Summary
- allow `.container-type` selects to shrink on small screens
- ignore `node_modules` in version control

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685859a24560832e85a0a1edc1ebf17f