### PR TITLE
Add basic tests and export server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -37,7 +37,12 @@ app.post('/order', (req, res) => {
 });
 
 // --------------------------------------------------
-// Server starten
+// Server starten (nur wenn nicht im Test)
 // --------------------------------------------------
-const PORT = 3000;
-app.listen(PORT, () => console.log(`API läuft auf Port ${PORT}`));
+const PORT = process.env.PORT || 3000;
+
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => console.log(`API läuft auf Port ${PORT}`));
+}
+
+export default app;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "NODE_ENV=test node --test"
   },
   "keywords": [],
   "author": "",

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import app from '../index.js';
+
+// Helper to start server on random port
+function startServer() {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+test('GET /products returns product list', async () => {
+  const server = await startServer();
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/products`);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.ok(Array.isArray(data));
+  server.close();
+});
+
+test('POST /order returns ok', async () => {
+  const server = await startServer();
+  const port = server.address().port;
+
+  const res = await fetch(`http://localhost:${port}/order`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ items: [] })
+  });
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.deepEqual(data, { status: 'ok' });
+  server.close();
+});


### PR DESCRIPTION
## Summary
- export Express app and avoid starting server when running tests
- add `.gitignore` for `node_modules`
- configure `npm test` to run Node's built-in test runner
- create basic tests for `/products` and `/order`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685860e2ed90832ea8dfce1f69203ab9