### PR TITLE
Improve mobile layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 row-flex">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>
@@ -69,7 +69,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 row-flex">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>

--- a/public/style.css
+++ b/public/style.css
@@ -320,3 +320,47 @@ select.form-select {
     width: 50% !important;
   }
 }
+
+/* Zusätzliche Mobile-Optimierung */
+@media (max-width: 768px) {
+  /* Formular volle Breite ohne Überlauf */
+  #orderForm,
+  .card {
+    width: 100%;
+    overflow: visible;
+  }
+
+  /* Behälter und Volumen nebeneinander */
+  .row-flex {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+  }
+  .row-flex > * {
+    flex: 1 1 50%;
+    max-width: 50%;
+  }
+
+  /* Einheitliche Label-Gestaltung */
+  label {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    white-space: normal;
+    word-break: break-word;
+  }
+
+  /* Bildplatzhalter ausblenden */
+  img.thumb {
+    display: none;
+  }
+
+  /* Gleichmäßiges Spacing innerhalb des Formulars */
+  #orderForm > * {
+    margin-bottom: 0.75rem;
+  }
+
+  /* Dropdown-Panels vollständig sichtbar */
+  select.form-select {
+    z-index: 999;
+  }
+}


### PR DESCRIPTION
## Summary
- add `.row-flex` wrappers for container/volume controls
- tweak mobile styling under 768px for single-column layout
- ignore `node_modules`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b00460e8c832ead0a4dd48c53bca6