### PR TITLE
Improve mobile layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 row-flex">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>
@@ -58,8 +58,18 @@
                       </select>
                     </div>
                   </td>
-                  <td class="sku align-middle">–</td>
-                  <td><input type="number" class="form-control qty" min="0" disabled></td>
+                  <td class="sku align-middle">
+                    <div class="line-flex">
+                      <span class="form-label mb-0">SKU</span>
+                      <span class="sku-value">–</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="line-flex">
+                      <label class="form-label mb-0">Menge</label>
+                      <input type="number" class="form-control qty" min="0" disabled>
+                    </div>
+                  </td>
                   <td class="sum text-end align-middle">0,00</td>
                 </tr>
                 <tr>
@@ -69,7 +79,7 @@
                     <img class="thumb" src="" alt="" height="48">
                   </td>
                   <td class="volume align-middle">
-                    <div class="d-flex gap-1">
+                    <div class="d-flex gap-1 row-flex">
                       <select class="form-select form-select-sm container-type">
                         <option value="" selected disabled>Behälter</option>
                         <option value="Flasche">Flasche</option>
@@ -80,8 +90,18 @@
                       </select>
                     </div>
                   </td>
-                  <td class="sku align-middle">–</td>
-                  <td><input type="number" class="form-control qty" min="0" disabled></td>
+                  <td class="sku align-middle">
+                    <div class="line-flex">
+                      <span class="form-label mb-0">SKU</span>
+                      <span class="sku-value">–</span>
+                    </div>
+                  </td>
+                  <td>
+                    <div class="line-flex">
+                      <label class="form-label mb-0">Menge</label>
+                      <input type="number" class="form-control qty" min="0" disabled>
+                    </div>
+                  </td>
                   <td class="sum text-end align-middle">0,00</td>
                 </tr>
               </tbody>

--- a/public/main.js
+++ b/public/main.js
@@ -179,7 +179,7 @@
           <img class="thumb" src="" alt="" height="48">
         </td>
         <td>
-          <div class="d-flex gap-1">
+          <div class="d-flex gap-1 row-flex">
             <select class="form-select form-select-sm container-type">
               <option value="" selected disabled>Behälter</option>
               <option value="Flasche">Flasche</option>
@@ -190,8 +190,18 @@
             </select>
           </div>
         </td>
-        <td class="sku align-middle">–</td>
-        <td><input type="number" class="form-control qty" min="0" disabled></td>
+        <td class="sku align-middle">
+          <div class="line-flex">
+            <span class="form-label mb-0">SKU</span>
+            <span class="sku-value">–</span>
+          </div>
+        </td>
+        <td>
+          <div class="line-flex">
+            <label class="form-label mb-0">Menge</label>
+            <input type="number" class="form-control qty" min="0" disabled>
+          </div>
+        </td>
         <td class="sum text-end align-middle">0,00</td>
       </tr>`;
     orderBody.insertAdjacentHTML('beforeend', rowHTML);

--- a/public/style.css
+++ b/public/style.css
@@ -320,3 +320,59 @@ select.form-select {
     width: 50% !important;
   }
 }
+
+/* Zusätzliche Mobile-Optimierung */
+@media (max-width: 768px) {
+  /* Formular und Tabelle breit halten, Dropdowns dürfen herausragen */
+  #orderForm,
+  .card,
+  .card table {
+    width: 100%;
+    overflow: visible;
+  }
+
+  /* Behälter und Volumen nebeneinander */
+  .row-flex {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+  }
+  .row-flex > * {
+    flex: 1 1 50%;
+    max-width: 50%;
+  }
+
+  /* SKU- und Mengen-Zeilen innerhalb der Zellen */
+  .line-flex {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .line-flex label {
+    margin-bottom: 0;
+  }
+
+  /* Einheitliche Label-Gestaltung */
+  label {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    white-space: normal;
+    word-break: break-word;
+  }
+
+  /* Bildplatzhalter ausblenden */
+  img.thumb {
+    display: none;
+  }
+
+  /* Gleichmäßiges Spacing innerhalb des Formulars */
+  #orderForm > * {
+    margin-bottom: 0.75rem;
+  }
+
+  /* Dropdown-Panels vollständig sichtbar */
+  select.form-select {
+    z-index: 999;
+  }
+}


### PR DESCRIPTION
## Summary
- add line-flex wrappers for SKU and quantity fields
- ensure new rows use row-flex and line-flex markup
- extend mobile styles for single-column layout and dropdown visibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b00460e8c832ead0a4dd48c53bca6